### PR TITLE
Fixes for JAGS 5.0.0

### DIFF
--- a/R/setup.jags.jagsfile.R
+++ b/R/setup.jags.jagsfile.R
@@ -377,7 +377,7 @@ setup.jagsfile <- function(model, n.chains=NA, data=NA, inits=NA, monitor=NA, mo
 		outdata <- checkdataformat(arg=data, block=maindata, auto=autodata, n.chains=NA, data.type=TRUE, evalscope=NULL)$combined
 	}
 
-	if(all(sapply(inits,class)%in%c('runjagsinits','character'))){
+	if(!is.environment(inits) && all(sapply(inits,class)%in%c('runjagsinits','character'))){
 		if((!identical(maininits, NA) || !identical(autoinits, NA)) && runjags.getOption('blockignore.warning'))
 			warning('Inits specified in the model file or using #inits# are ignored when a character string is given as the argument to inits', call.=FALSE)
 		maininits <- NA

--- a/R/template_huiwalter.R
+++ b/R/template_huiwalter.R
@@ -480,23 +480,33 @@ template_huiwalter <- function(testdata, outfile='huiwalter_model.txt', covarian
 		x <- rep(x,times=ceiling(len/length(x)))
 		return(x[1:len])
 	}
-	if(cov_as_cor){
-	  cvn <- apply(expand.grid(apply(testcombos,1,paste,collapse=''), c('corse','corsp'))[,2:1],1,paste,collapse='')
-	}else{
-	  cvn <- apply(expand.grid(apply(testcombos,1,paste,collapse=''), c('covse','covsp'))[,2:1],1,paste,collapse='')
+        ## Set initial values for active covariances/correlations
+        tp_se <- !is.na(testpairs[,"Active_Se"]) & testpairs[,"Active_Se"]
+        tp_sp <- !is.na(testpairs[,"Active_Sp"]) & testpairs[,"Active_Sp"]
+        if (cov_as_cor){
+            cvn <- c(paste0("corse", testpairs[,"Suffix"])[tp_se],
+                     paste0("corsp", testpairs[,"Suffix"])[tp_sp])
+	} else{
+            cvn <- c(paste0("covse", testpairs[,"Suffix"])[tp_se],
+                     paste0("covsp", testpairs[,"Suffix"])[tp_sp])
 	}
-	# Fails to initialise with anything other than 0:
-	covinitvals <- as.list(alternate(c(0,0), length(cvn)))
-	names(covinitvals) <- cvn
-	covinits <- c(dump.format(covinitvals), dump.format(lapply(covinitvals, function(x) -x)))
+        if (length(cvn) > 0) {
+            ## Fails to initialise with anything other than 0:
+            covinitvals <- rep(list(0), length(cvn))
+	    names(covinitvals) <- cvn
+	    covinits <- rep(dump.format(covinitvals), 2)
+        }
+        else {
+            covinits <- NULL
+        }
 	if(FALSE){
 	  covinits <- gsub('\"cov', '# \"cov', covinits, fixed=TRUE)
 	  covinits <- gsub('\"cor', '# \"cor', covinits, fixed=TRUE)
 	}
 
-	initblock <- c(dump.format(list(se=alternate(c(0.5,0.99), length(testcols)), sp=alternate(c(0.99,0.75), length(testcols)), prev=alternate(c(0.05,0.95), length(levels(testdata$Population)))))) #, covinits[1])
+	initblock <- c(dump.format(list(se=alternate(c(0.5,0.99), length(testcols)), sp=alternate(c(0.99,0.75), length(testcols)), prev=alternate(c(0.05,0.95), length(levels(testdata$Population))))), covinits[1]) 
 	cat('\n\n## Inits:\ninits{\n', initblock, '}', sep='', file=outfile, append=TRUE)
-	initblock <- c(dump.format(list(se=alternate(c(0.5,0.99)[2:1], length(testcols)), sp=alternate(c(0.99,0.75)[2:1], length(testcols)), prev=alternate(c(0.05,0.95)[2:1], length(levels(testdata$Population)))))) #, covinits[2])
+	initblock <- c(dump.format(list(se=alternate(c(0.5,0.99)[2:1], length(testcols)), sp=alternate(c(0.99,0.75)[2:1], length(testcols)), prev=alternate(c(0.05,0.95)[2:1], length(levels(testdata$Population))))), covinits[2])
 	cat('\ninits{\n', initblock, '}', sep='', file=outfile, append=TRUE)
 
 	## Data:

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -657,7 +657,7 @@ assign("simfolders", character(0), envir=runjagsprivate)
 assign("failedsimfolders", character(0), envir=runjagsprivate)
 assign("defaultsummarypars", list(vars=NA, mutate=NULL, psrf.target = 1.05, normalise.mcmc = TRUE, modeest.opts=list(), confidence=c(0.95), autocorr.lags=c(10), custom=NULL, silent.jags=expression(runjags.getOption('silent.jags')), plots=FALSE, plot.type=c('trace','ecdf','histogram','autocorr','key','crosscorr'), col=NA, summary.iters=10000, trace.iters=1000, separate.chains=FALSE, trace.options=list(), density.options=list(), histogram.options=list(), ecdfplot.options=list(), acplot.options=list()), envir=runjagsprivate)
 assign("minjagsmajor", 3, envir=runjagsprivate)
-assign("maxjagsmajor", 4, envir=runjagsprivate)
+assign("maxjagsmajor", 5, envir=runjagsprivate)
 assign("warned_version_mismatch", FALSE, envir=runjagsprivate)
 assign("warned_macos_lipo", FALSE, envir=runjagsprivate)
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -514,6 +514,7 @@ testjags <- function(jags=runjags.getOption('jagspath'), silent=FALSE){
 			if(grepl('(', versioncom, fixed=TRUE)){
 				versioncom <- strsplit(versioncom, split='(', fixed=TRUE)[[1]][1]
 			}
+			versioncom <- sub("-beta$", "", versioncom)
 			versioncom <- sub('.',';',versioncom,fixed=TRUE)
 			versioncom <- gsub('.','',versioncom,fixed=TRUE)
 			num.version <- as.numeric(gsub(';','.',versioncom,fixed=TRUE))

--- a/src/jagsversions.h
+++ b/src/jagsversions.h
@@ -48,7 +48,7 @@
 #endif // JAGS_MAJOR_ASSUMED
 
 // Check version of JAGS is OK:
-#if JAGS_MAJOR_USED > 4
+#if JAGS_MAJOR_USED > 5
 #warning "Compiling against a later version of JAGS than has been tested for this version of runjags ... you should probably update the runjags package!"
 #endif
 


### PR DESCRIPTION
With the forthcoming release of JAGS 5.0.0 I'm trying to get all of the reverse dependencies of the rjags package on CRAN working with the current development version of JAGS. This will take a while, but the runjags package is one of the primary interfaces to JAGS on R and so is a priority.

The good news is that the changes are  minimal and are backward compatible, so my pull request does not create a hard dependency on JAGS >= 5.0.0 or rjags >= 5. However, if you are testing this with JAGS 5 then you need to be using the development branch of mcmc-jags-rjags from today onwards:

changeset:   332:bc493136a5ad
tag:         tip
user:        martyn_plummer@sourceforge.net
date:        Sat Jan 03 11:16:12 2026 +0000
summary:     Fixes for runjags compatibility

Testing the runjags package revealed quite a few bugs and back-compatibility problems in the development version of rjags so this is a two-way street.

The main change as far as the runjags package is concerned is that JAGS no longer uses "typical" starting values for the parameters but samples them from the prior distribution. This meant that I had to make changes to the Hui-Walter template code to ensure that the covariance parameters were explicitly initialized to zero. 

This change also revealed that the starting values in the quickjags.Rmd vignette were never used. This was not evident before since JAGS 4.0.0 chose sensible "typical" starting values. But JAGS 5.0.0 draws the starting values from the diffuse normal priors which does not work and building the vignette fails. I've made a change to R/setup.jags.jagsfile.R to prevent the code going down the wrong path. The problem here is that the initial values are set to the Global environment which, when building the vignette, contains a single character variable `filestring` containing the model. It does not contain initial values and, in my view, the code should not go down this path which is designed for when your provide a list of character starting values.

I also made changes to R/utilities.R and src/jagsversions.h purely to check that I could get runjags to pass `R CMD check` without any warnings.

Thanks for all the work on the runjags package and for sticking with JAGS all these years. I tried to make the rjags interface as minimal as possible. You have made an impressively user-friendly interface.